### PR TITLE
feat: implement scan-tile relationship management and enhance tile handling

### DIFF
--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -22,6 +22,8 @@ import type * as lib_tiles from "../lib/tiles.js";
 import type * as migrations from "../migrations.js";
 import type * as scanResults from "../scanResults.js";
 import type * as scans from "../scans.js";
+import type * as scans_x_tiles from "../scans_x_tiles.js";
+import type * as tiles from "../tiles.js";
 import type * as users from "../users.js";
 
 import type {
@@ -53,6 +55,8 @@ declare const fullApi: ApiFromModules<{
   migrations: typeof migrations;
   scanResults: typeof scanResults;
   scans: typeof scans;
+  scans_x_tiles: typeof scans_x_tiles;
+  tiles: typeof tiles;
   users: typeof users;
 }>;
 declare const fullApiWithMounts: typeof fullApi;

--- a/convex/actions.ts
+++ b/convex/actions.ts
@@ -117,10 +117,8 @@ const processTile = async (
   });
 
   // Check for existing inference
-  const existing = await ctx.runQuery(internal.inferences.getLatestByTile, {
-    z: tile.z,
-    x: tile.x,
-    y: tile.y,
+  const existing = await ctx.runQuery(internal.inferences.getLatestByTileId, {
+    tileId,
     model: ROBOFLOW_MODEL_NAME,
     version: ROBOFLOW_MODEL_VERSION,
   });
@@ -147,11 +145,9 @@ const processTile = async (
 
   // Upsert inference record
   const inferenceId: Id<'inferences'> = await ctx.runMutation(
-    internal.inferences.upsert,
+    internal.inferences.upsertByTileId,
     {
-      z: tile.z,
-      x: tile.x,
-      y: tile.y,
+      tileId,
       imageUrl: tile.url,
       model: ROBOFLOW_MODEL_NAME,
       version: ROBOFLOW_MODEL_VERSION,

--- a/convex/actions.ts
+++ b/convex/actions.ts
@@ -160,6 +160,7 @@ const processTile = async (
     detections.predictions.map(async (prediction) => {
       return await ctx.runMutation(internal.inference_predictions.upsert, {
         inferenceId,
+        tileId,
         prediction,
       });
     })

--- a/convex/feedback_submissions.ts
+++ b/convex/feedback_submissions.ts
@@ -108,6 +108,7 @@ export const submitFeedback = mutation({
     }
 
     await ctx.db.insert('feedback_submissions', {
+      tileId: prediction.tileId,
       inferenceId: prediction.inferenceId,
       predictionId: args.predictionId,
       userId: userId,

--- a/convex/migrations.ts
+++ b/convex/migrations.ts
@@ -19,6 +19,7 @@ export const migratePredictions = migrations.define({
       predictions.map(async (prediction) => {
         return await ctx.runMutation(internal.inference_predictions.upsert, {
           inferenceId: doc._id,
+          tileId: doc.tileId as Id<'tiles'>,
           prediction,
         });
       })
@@ -123,6 +124,20 @@ export const migrateInferenceTileId = migrations.define({
   },
 });
 
+export const migrateInferencePredictionsTileandDetectionId = migrations.define({
+  table: 'inference_predictions',
+  migrateOne: async (ctx, doc) => {
+    const inference = await ctx.db.get(doc.inferenceId);
+    if (!inference?.tileId) return;
+
+    return {
+      tileId: inference.tileId,
+      roboflowDetectionId: doc.detectionId,
+      detectionId: undefined,
+    };
+  },
+});
+
 export const runAll = migrations.runner([
   internal.migrations.migratePredictions,
   internal.migrations.migrateScansCenterTile,
@@ -131,4 +146,5 @@ export const runAll = migrations.runner([
   internal.migrations.removeSwimmingPoolFeedback,
   internal.migrations.migrateScansAndTiles,
   internal.migrations.migrateInferenceTileId,
+  internal.migrations.migrateInferencePredictionsTileandDetectionId,
 ]);

--- a/convex/migrations.ts
+++ b/convex/migrations.ts
@@ -138,6 +138,23 @@ export const migrateInferencePredictionsTileandDetectionId = migrations.define({
   },
 });
 
+export const migrateFeedbackSubmissionsTileandBatchId = migrations.define({
+  table: 'feedback_submissions',
+  migrateOne: async (ctx, doc) => {
+    const prediction = await ctx.db.get(doc.predictionId);
+    const tileId = prediction?.tileId;
+    const batchId = doc.lastBatchId;
+
+    return {
+      tileId,
+      batchId,
+      inferenceId: undefined,
+      lastBatchId: undefined,
+      uploadStatus: undefined,
+    };
+  },
+});
+
 export const runAll = migrations.runner([
   internal.migrations.migratePredictions,
   internal.migrations.migrateScansCenterTile,
@@ -147,4 +164,5 @@ export const runAll = migrations.runner([
   internal.migrations.migrateScansAndTiles,
   internal.migrations.migrateInferenceTileId,
   internal.migrations.migrateInferencePredictionsTileandDetectionId,
+  internal.migrations.migrateFeedbackSubmissionsTileandBatchId,
 ]);

--- a/convex/scans_x_tiles.ts
+++ b/convex/scans_x_tiles.ts
@@ -1,0 +1,104 @@
+import {
+  internalMutation,
+  internalQuery,
+  mutation,
+  query,
+} from './_generated/server';
+import { v } from 'convex/values';
+import { Doc } from './_generated/dataModel';
+
+// Query to check if a scan-tile relationship already exists
+export const getScanTileRelationship = query({
+  args: {
+    scanId: v.id('scans'),
+    tileId: v.id('tiles'),
+  },
+  handler: async (ctx, { scanId, tileId }) => {
+    return await ctx.db
+      .query('scans_x_tiles')
+      .withIndex('by_scan_and_tile', (q) =>
+        q.eq('scanId', scanId).eq('tileId', tileId)
+      )
+      .unique();
+  },
+});
+
+// Mutation to create a scan-tile relationship only if it doesn't already exist
+export const insertScanTileRelationshipIfNotExists = internalMutation({
+  args: {
+    scanId: v.id('scans'),
+    tileId: v.id('tiles'),
+  },
+  handler: async (ctx, { scanId, tileId }) => {
+    // Check if relationship already exists
+    const existingRelationship = await ctx.db
+      .query('scans_x_tiles')
+      .withIndex('by_scan_and_tile', (q) =>
+        q.eq('scanId', scanId).eq('tileId', tileId)
+      )
+      .unique();
+
+    if (existingRelationship) {
+      return existingRelationship._id;
+    }
+
+    // Create new relationship
+    return await ctx.db.insert('scans_x_tiles', { scanId, tileId });
+  },
+});
+
+// Get all tiles for a specific scan
+export const getTilesForScan = internalQuery({
+  args: {
+    scanId: v.id('scans'),
+  },
+  handler: async (ctx, { scanId }) => {
+    const relationships = await ctx.db
+      .query('scans_x_tiles')
+      .withIndex('by_scan_and_tile', (q) => q.eq('scanId', scanId))
+      .collect();
+
+    // Get the actual tile documents
+    const tiles = await Promise.all(
+      relationships.map(async (rel) => {
+        const tile = await ctx.db.get(rel.tileId);
+        return tile;
+      })
+    );
+
+    return tiles.filter(Boolean) as Doc<'tiles'>[];
+  },
+});
+
+// Batch insert scan-tile relationships (useful for migrations)
+export const insertScanTileRelationshipsBatch = mutation({
+  args: {
+    scanId: v.id('scans'),
+    tileIds: v.array(v.id('tiles')),
+  },
+  handler: async (ctx, { scanId, tileIds }) => {
+    const relationshipIds = [];
+
+    for (const tileId of tileIds) {
+      // Check if relationship already exists
+      const existingRelationship = await ctx.db
+        .query('scans_x_tiles')
+        .withIndex('by_scan_and_tile', (q) =>
+          q.eq('scanId', scanId).eq('tileId', tileId)
+        )
+        .unique();
+
+      if (existingRelationship) {
+        relationshipIds.push(existingRelationship._id);
+      } else {
+        const relationshipId = await ctx.db.insert('scans_x_tiles', {
+          scanId,
+          tileId,
+        });
+        relationshipIds.push(relationshipId);
+      }
+    }
+
+    return relationshipIds;
+  },
+});

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -44,25 +44,34 @@ export default defineSchema({
     .index('by_inference', ['inferenceId'])
     .index('by_inference_and_detection', ['inferenceId', 'detectionId']),
   inferences: defineTable({
-    imageUrl: v.string(),
+    tileId: v.optional(v.id('tiles')),
     model: v.string(),
-    requestedAt: v.float64(),
-    response: v.any(),
     version: v.string(),
+    response: v.any(),
+
+    // REMOVE BELOW
+    imageUrl: v.string(),
+    requestedAt: v.float64(),
     x: v.float64(),
     y: v.float64(),
     z: v.float64(),
-  }).index('by_tile', ['z', 'x', 'y', 'model', 'version']),
+  })
+    .index('by_tile', ['z', 'x', 'y', 'model', 'version'])
+    .index('by_tileId', ['tileId', 'model', 'version']),
   scans: defineTable({
+    userId: v.optional(v.id('users')),
+    model: v.optional(v.string()),
+    version: v.optional(v.string()),
+    radius: v.optional(v.number()),
     centerLat: v.float64(),
     centerLong: v.float64(),
-    // REMOVE
+
+    // REMOVE BELOW
     centerTile: v.object({
       x: v.float64(),
       y: v.float64(),
       z: v.float64(),
     }),
-    // REMOVE
     tiles: v.optional(
       v.array(
         v.object({
@@ -72,10 +81,6 @@ export default defineSchema({
         })
       )
     ),
-    model: v.optional(v.string()), // NEW
-    version: v.optional(v.string()), // NEW
-    radius: v.optional(v.number()), // NEW
-    userId: v.optional(v.id('users')),
   })
     .index('by_center', ['centerLat', 'centerLong'])
     .index('by_center_tile', ['centerTile']),

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -91,35 +91,11 @@ export default defineSchema({
     ),
   }).index('by_center_tile', ['centerTile']),
   upload_batches: defineTable({
-    annotationCount: v.float64(),
-    batchId: v.string(),
-    createdAt: v.optional(v.float64()),
-    createdBy: v.optional(v.id('users')),
-    feedbackCount: v.float64(),
-    imageUrl: v.string(),
-    inferenceId: v.id('inferences'),
-    reviewNotes: v.optional(v.string()),
-    reviewedAt: v.optional(v.float64()),
-    reviewedBy: v.optional(v.id('users')),
-    roboflowAnnotationId: v.optional(v.string()),
-    roboflowImageId: v.optional(v.string()),
-    status: v.union(
-      v.literal('pending'),
-      v.literal('processing'),
-      v.literal('uploaded'),
-      v.literal('failed'),
-      v.literal('approved'),
-      v.literal('rejected')
-    ),
-    tileCoordinates: v.object({
-      x: v.float64(),
-      y: v.float64(),
-      z: v.float64(),
-    }),
-  })
-    .index('by_inference', ['inferenceId'])
-    .index('by_status', ['status'])
-    .index('by_tile', ['tileCoordinates']),
+    tileId: v.id('tiles'),
+    roboflowName: v.string(),
+    roboflowImageId: v.string(),
+    roboflowAnnotationId: v.string(),
+  }),
   tiles: defineTable({
     x: v.float64(),
     y: v.float64(),

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -31,18 +31,26 @@ export default defineSchema({
     .index('by_upload_status', ['uploadStatus'])
     .index('by_user_and_prediction', ['userId', 'predictionId']),
   inference_predictions: defineTable({
+    roboflowDetectionId: v.optional(v.string()),
+    tileId: v.optional(v.id('tiles')),
+    inferenceId: v.id('inferences'),
     class: v.string(),
     classId: v.optional(v.float64()),
     confidence: v.float64(),
-    detectionId: v.string(),
     height: v.float64(),
-    inferenceId: v.id('inferences'),
     width: v.float64(),
     x: v.float64(),
     y: v.float64(),
+
+    // REMOVE BELOW
+    detectionId: v.optional(v.string()),
   })
     .index('by_inference', ['inferenceId'])
-    .index('by_inference_and_detection', ['inferenceId', 'detectionId']),
+    .index('by_inference_and_detection', ['inferenceId', 'detectionId'])
+    .index('by_inf_and_roboflow_detection_id', [
+      'inferenceId',
+      'roboflowDetectionId',
+    ]),
   inferences: defineTable({
     tileId: v.optional(v.id('tiles')),
     model: v.string(),

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -12,53 +12,110 @@ export default defineSchema({
     isAnonymous: v.optional(v.boolean()),
     permissions: v.array(v.string()),
   }).index('email', ['email']),
-  scans: defineTable({
-    centerLat: v.number(),
-    centerLong: v.number(),
-    centerTile: v.object({
-      z: v.number(),
-      x: v.number(),
-      y: v.number(),
-    }),
-    tiles: v.array(
-      v.object({
-        z: v.number(),
-        x: v.number(),
-        y: v.number(),
-      })
+  feedback_submissions: defineTable({
+    inferenceId: v.id('inferences'),
+    lastBatchId: v.optional(v.id('upload_batches')),
+    predictionId: v.id('inference_predictions'),
+    uploadStatus: v.optional(
+      v.union(
+        v.literal('pending'),
+        v.literal('batched'),
+        v.literal('uploaded'),
+        v.literal('failed')
+      )
     ),
+    userId: v.id('users'),
+    userResponse: v.string(),
+  })
+    .index('by_inference', ['inferenceId'])
+    .index('by_upload_status', ['uploadStatus'])
+    .index('by_user_and_prediction', ['userId', 'predictionId']),
+  inference_predictions: defineTable({
+    class: v.string(),
+    classId: v.optional(v.float64()),
+    confidence: v.float64(),
+    detectionId: v.string(),
+    height: v.float64(),
+    inferenceId: v.id('inferences'),
+    width: v.float64(),
+    x: v.float64(),
+    y: v.float64(),
+  })
+    .index('by_inference', ['inferenceId'])
+    .index('by_inference_and_detection', ['inferenceId', 'detectionId']),
+  inferences: defineTable({
+    imageUrl: v.string(),
+    model: v.string(),
+    requestedAt: v.float64(),
+    response: v.any(),
+    version: v.string(),
+    x: v.float64(),
+    y: v.float64(),
+    z: v.float64(),
+  }).index('by_tile', ['z', 'x', 'y', 'model', 'version']),
+  scans: defineTable({
+    centerLat: v.float64(),
+    centerLong: v.float64(),
+    // REMOVE
+    centerTile: v.object({
+      x: v.float64(),
+      y: v.float64(),
+      z: v.float64(),
+    }),
+    // REMOVE
+    tiles: v.optional(
+      v.array(
+        v.object({
+          x: v.float64(),
+          y: v.float64(),
+          z: v.float64(),
+        })
+      )
+    ),
+    model: v.optional(v.string()), // NEW
+    version: v.optional(v.string()), // NEW
+    radius: v.optional(v.number()), // NEW
     userId: v.optional(v.id('users')),
   })
     .index('by_center', ['centerLat', 'centerLong'])
     .index('by_center_tile', ['centerTile']),
-  inferences: defineTable({
-    // Slippy tile coordinates
-    z: v.number(),
-    x: v.number(),
-    y: v.number(),
+  upload_batches: defineTable({
+    annotationCount: v.float64(),
+    batchId: v.string(),
+    createdAt: v.optional(v.float64()),
+    createdBy: v.optional(v.id('users')),
+    feedbackCount: v.float64(),
     imageUrl: v.string(),
-    model: v.string(),
-    version: v.string(),
-    requestedAt: v.number(),
-    response: v.any(),
-  }).index('by_tile', ['z', 'x', 'y', 'model', 'version']),
-  inference_predictions: defineTable({
     inferenceId: v.id('inferences'),
-    class: v.string(),
-    confidence: v.number(),
-    height: v.number(),
-    width: v.number(),
-    x: v.number(),
-    y: v.number(),
-    classId: v.optional(v.number()),
-    detectionId: v.string(),
+    reviewNotes: v.optional(v.string()),
+    reviewedAt: v.optional(v.float64()),
+    reviewedBy: v.optional(v.id('users')),
+    roboflowAnnotationId: v.optional(v.string()),
+    roboflowImageId: v.optional(v.string()),
+    status: v.union(
+      v.literal('pending'),
+      v.literal('processing'),
+      v.literal('uploaded'),
+      v.literal('failed'),
+      v.literal('approved'),
+      v.literal('rejected')
+    ),
+    tileCoordinates: v.object({
+      x: v.float64(),
+      y: v.float64(),
+      z: v.float64(),
+    }),
   })
     .index('by_inference', ['inferenceId'])
-    .index('by_inference_and_detection', ['inferenceId', 'detectionId']),
-  feedback_submissions: defineTable({
-    inferenceId: v.id('inferences'),
-    predictionId: v.id('inference_predictions'),
-    userId: v.id('users'),
-    userResponse: v.string(),
-  }).index('by_user_and_prediction', ['userId', 'predictionId']),
+    .index('by_status', ['status'])
+    .index('by_tile', ['tileCoordinates']),
+  tiles: defineTable({
+    x: v.float64(),
+    y: v.float64(),
+    z: v.float64(),
+  }).index('by_tile', ['x', 'y', 'z']),
+  scans_x_tiles: defineTable({
+    scanId: v.id('scans'),
+    tileId: v.id('tiles'),
+  }).index('by_scan_and_tile', ['scanId', 'tileId']),
 });

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -13,9 +13,15 @@ export default defineSchema({
     permissions: v.array(v.string()),
   }).index('email', ['email']),
   feedback_submissions: defineTable({
-    inferenceId: v.id('inferences'),
-    lastBatchId: v.optional(v.id('upload_batches')),
     predictionId: v.id('inference_predictions'),
+    userId: v.id('users'),
+    userResponse: v.string(),
+    tileId: v.optional(v.id('tiles')),
+    batchId: v.optional(v.id('upload_batches')),
+
+    // REMOVE BELOW
+    inferenceId: v.optional(v.id('inferences')),
+    lastBatchId: v.optional(v.id('upload_batches')),
     uploadStatus: v.optional(
       v.union(
         v.literal('pending'),
@@ -24,12 +30,7 @@ export default defineSchema({
         v.literal('failed')
       )
     ),
-    userId: v.id('users'),
-    userResponse: v.string(),
-  })
-    .index('by_inference', ['inferenceId'])
-    .index('by_upload_status', ['uploadStatus'])
-    .index('by_user_and_prediction', ['userId', 'predictionId']),
+  }).index('by_user_and_prediction', ['userId', 'predictionId']),
   inference_predictions: defineTable({
     roboflowDetectionId: v.optional(v.string()),
     tileId: v.optional(v.id('tiles')),
@@ -46,7 +47,6 @@ export default defineSchema({
     detectionId: v.optional(v.string()),
   })
     .index('by_inference', ['inferenceId'])
-    .index('by_inference_and_detection', ['inferenceId', 'detectionId'])
     .index('by_inf_and_roboflow_detection_id', [
       'inferenceId',
       'roboflowDetectionId',
@@ -89,9 +89,7 @@ export default defineSchema({
         })
       )
     ),
-  })
-    .index('by_center', ['centerLat', 'centerLong'])
-    .index('by_center_tile', ['centerTile']),
+  }).index('by_center_tile', ['centerTile']),
   upload_batches: defineTable({
     annotationCount: v.float64(),
     batchId: v.string(),

--- a/convex/tiles.ts
+++ b/convex/tiles.ts
@@ -1,3 +1,4 @@
+import { Id } from './_generated/dataModel';
 import { internalMutation, internalQuery, query } from './_generated/server';
 import { v } from 'convex/values';
 

--- a/convex/tiles.ts
+++ b/convex/tiles.ts
@@ -1,0 +1,67 @@
+import { internalMutation, internalQuery, query } from './_generated/server';
+import { v } from 'convex/values';
+
+// Query to check if a tile already exists
+export const getTileByCoordinates = query({
+  args: {
+    x: v.float64(),
+    y: v.float64(),
+    z: v.float64(),
+  },
+  handler: async (ctx, { x, y, z }) => {
+    return await ctx.db
+      .query('tiles')
+      .withIndex('by_tile', (q) => q.eq('x', x).eq('y', y).eq('z', z))
+      .unique();
+  },
+});
+
+// Mutation to insert a tile only if it doesn't already exist
+export const insertTileIfNotExists = internalMutation({
+  args: {
+    x: v.float64(),
+    y: v.float64(),
+    z: v.float64(),
+  },
+  handler: async (ctx, { x, y, z }) => {
+    // Check if tile already exists
+    const existingTile = await ctx.db
+      .query('tiles')
+      .withIndex('by_tile', (q) => q.eq('x', x).eq('y', y).eq('z', z))
+      .unique();
+
+    if (existingTile) return existingTile._id;
+
+    return await ctx.db.insert('tiles', { x, y, z });
+  },
+});
+
+// Alternative: Upsert pattern (insert or update)
+export const upsertTile = internalMutation({
+  args: {
+    x: v.float64(),
+    y: v.float64(),
+    z: v.float64(),
+  },
+  handler: async (ctx, { x, y, z }) => {
+    // Check if tile already exists
+    const existingTile = await ctx.db
+      .query('tiles')
+      .withIndex('by_tile', (q) => q.eq('x', x).eq('y', y).eq('z', z))
+      .unique();
+
+    if (existingTile) {
+      return existingTile._id;
+    }
+
+    // Insert new tile
+    return await ctx.db.insert('tiles', { x, y, z });
+  },
+});
+
+// Get all tiles (useful for debugging)
+export const getAllTiles = internalQuery({
+  handler: async (ctx) => {
+    return await ctx.db.query('tiles').collect();
+  },
+});

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -22,7 +22,7 @@ update the document to detail that the permissions Strings are all stored in the
   - COCO JSON looks widely supported https://roboflow.com/formats/coco-json
 - CreateML JSON is so much simpler to write thooooo
 
-# Uploading Images To Roboflow
+## Uploading Images To Roboflow
 
 1. create CreateML.json for image NAME
 2. hit the .../upload endpoint
@@ -43,3 +43,9 @@ Let's show the user how many predictions they have left to evaluate this number 
   - implementing a currency system?
   - allowing users to set the radius of their scan (gotta store the radius)
   - having the scan radius larger in production
+
+## Support different map styles
+
+- the satellite view is sometimes too much
+- having support for the street map (light and dark!) would be nice
+- should just have to change a string in the mapbox api request

--- a/src/components/header.tsx
+++ b/src/components/header.tsx
@@ -32,7 +32,7 @@ export default function Header() {
             <img
               src='/logo.webp'
               alt='Court Finder'
-              className='h-8 w-auto sm:h-10'
+              className='p-0.5 md:p-1 h-8 w-auto sm:h-10'
             />
             <span className='pl-4 font-semibold text-lg tracking-tight'>
               Court Finder


### PR DESCRIPTION
- Added new `scans_x_tiles` module to manage relationships between scans and tiles.
- Introduced mutations and queries for inserting and retrieving scan-tile relationships.
- Updated existing actions to ensure tiles are created and linked during scan processing.
- Enhanced schema to support new relationships and added necessary indices.
- Refactored related actions and queries to utilize the new structure for improved data integrity.