### PR TITLE
Migrate to @t3-oss/env-core for type-safe environment variables

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -15,6 +15,7 @@
         "@radix-ui/react-progress": "^1.1.7",
         "@radix-ui/react-switch": "^1.2.6",
         "@radix-ui/react-tabs": "^1.1.13",
+        "@t3-oss/env-core": "^0.13.11",
         "@tailwindcss/vite": "^4.1.13",
         "@tanstack/react-form": "^1.20.0",
         "@tanstack/react-query": "^5.89.0",
@@ -587,6 +588,8 @@
     "@standard-schema/utils": ["@standard-schema/utils@0.3.0", "", {}, "sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g=="],
 
     "@surma/rollup-plugin-off-main-thread": ["@surma/rollup-plugin-off-main-thread@2.2.3", "", { "dependencies": { "ejs": "^3.1.6", "json5": "^2.2.0", "magic-string": "^0.25.0", "string.prototype.matchall": "^4.0.6" } }, "sha512-lR8q/9W7hZpMWweNiAKU7NQerBnzQQLvi8qnTDU/fxItPhtZVMbPV3lbCwjhIlNBe9Bbr5V+KHshvWmVSG9cxQ=="],
+
+    "@t3-oss/env-core": ["@t3-oss/env-core@0.13.11", "", { "peerDependencies": { "arktype": "^2.1.0", "typescript": ">=5.0.0", "valibot": "^1.0.0-beta.7 || ^1.0.0", "zod": "^3.24.0 || ^4.0.0" }, "optionalPeers": ["arktype", "typescript", "valibot", "zod"] }, "sha512-sM7GYY+KL7H/Hl0BE0inWfk3nRHZOLhmVn7sHGxaZt9FAR6KqREXAE+6TqKfiavfXmpRxO/OZ2QgKRd+oiBYRQ=="],
 
     "@tailwindcss/node": ["@tailwindcss/node@4.1.13", "", { "dependencies": { "@jridgewell/remapping": "^2.3.4", "enhanced-resolve": "^5.18.3", "jiti": "^2.5.1", "lightningcss": "1.30.1", "magic-string": "^0.30.18", "source-map-js": "^1.2.1", "tailwindcss": "4.1.13" } }, "sha512-eq3ouolC1oEFOAvOMOBAmfCIqZBJuvWvvYWh5h5iOYfe1HFC6+GZ6EIL0JdM3/niGRJmnrOc+8gl9/HGUaaptw=="],
 

--- a/convex/actions.ts
+++ b/convex/actions.ts
@@ -48,24 +48,6 @@ type ScanAreaReturn = {
   tiles: ScanResult[];
 };
 
-// Helper functions
-const validateEnvironmentVariables = (): {
-  mapboxToken: string;
-  roboflowKey: string;
-} => {
-  const mapboxToken = env.MAPBOX_API_KEY;
-  const roboflowKey = env.ROBOFLOW_API_KEY;
-
-  if (!mapboxToken) {
-    throw new Error('Missing MAPBOX_API_KEY environment variable');
-  }
-  if (!roboflowKey) {
-    throw new Error('Missing ROBOFLOW_API_KEY environment variable');
-  }
-
-  return { mapboxToken, roboflowKey };
-};
-
 type TileWithUrl = TileCoordinate & { url: string };
 
 const processTile = async (
@@ -194,8 +176,7 @@ export const startScanArea = action({
       throw new Error('Unauthorized');
     }
 
-    // Validate environment variables
-    const { mapboxToken } = validateEnvironmentVariables();
+    const mapboxToken = env.MAPBOX_API_KEY;
 
     // Generate tile coverage
     const coverage = tilesInRadiusFromPoint(
@@ -247,8 +228,8 @@ export const processScanArea = internalAction({
   handler: async (ctx: ActionCtx, args) => {
     const startTs = Date.now();
 
-    // Validate environment variables
-    const { mapboxToken, roboflowKey } = validateEnvironmentVariables();
+    const mapboxToken = env.MAPBOX_API_KEY;
+    const roboflowKey = env.ROBOFLOW_API_KEY;
 
     // Generate tile coverage (same as startScanArea)
     const coverage = tilesInRadiusFromPoint(
@@ -340,8 +321,8 @@ export const scanArea = action({
       throw new Error('Unauthorized');
     }
 
-    // Validate environment variables
-    const { mapboxToken, roboflowKey } = validateEnvironmentVariables();
+    const mapboxToken = env.MAPBOX_API_KEY;
+    const roboflowKey = env.ROBOFLOW_API_KEY;
 
     // Log scan start
     console.log('start', {

--- a/convex/actions.ts
+++ b/convex/actions.ts
@@ -16,9 +16,9 @@ import {
   ROBOFLOW_MODEL_NAME,
   ROBOFLOW_MODEL_VERSION,
   DEFAULT_TILE_RADIUS,
-  ENV_VARS,
 } from './lib/constants';
 import { getAuthUserId } from '@convex-dev/auth/server';
+import { env } from './env';
 
 // Types
 type ScanResult = {
@@ -53,8 +53,8 @@ const validateEnvironmentVariables = (): {
   mapboxToken: string;
   roboflowKey: string;
 } => {
-  const mapboxToken = process.env[ENV_VARS.MAPBOX_API_KEY];
-  const roboflowKey = process.env[ENV_VARS.ROBOFLOW_API_KEY];
+  const mapboxToken = env.MAPBOX_API_KEY;
+  const roboflowKey = env.ROBOFLOW_API_KEY;
 
   if (!mapboxToken) {
     throw new Error('Missing MAPBOX_API_KEY environment variable');

--- a/convex/auth.config.ts
+++ b/convex/auth.config.ts
@@ -1,9 +1,7 @@
-import { env } from './env';
-
 export default {
   providers: [
     {
-      domain: env.CONVEX_SITE_URL,
+      domain: process.env.CONVEX_SITE_URL,
       applicationID: "convex",
     },
   ],

--- a/convex/auth.config.ts
+++ b/convex/auth.config.ts
@@ -1,7 +1,9 @@
+import { env } from './env';
+
 export default {
   providers: [
     {
-      domain: process.env.CONVEX_SITE_URL,
+      domain: env.CONVEX_SITE_URL,
       applicationID: "convex",
     },
   ],

--- a/convex/env.ts
+++ b/convex/env.ts
@@ -1,0 +1,13 @@
+import { createEnv } from "@t3-oss/env-core";
+import { z } from "zod";
+
+export const env = createEnv({
+  server: {
+    MAPBOX_API_KEY: z.string().min(1),
+    ROBOFLOW_API_KEY: z.string().min(1),
+    ROBOFLOW_BATCH: z.string().optional(),
+    CONVEX_SITE_URL: z.string().optional(),
+  },
+  runtimeEnv: process.env,
+  emptyStringAsUndefined: true,
+});

--- a/convex/env.ts
+++ b/convex/env.ts
@@ -5,7 +5,7 @@ export const env = createEnv({
   server: {
     MAPBOX_API_KEY: z.string().min(1),
     ROBOFLOW_API_KEY: z.string().min(1),
-    ROBOFLOW_BATCH: z.string().optional(),
+    ROBOFLOW_BATCH: z.string().default('User Contributed'),
     CONVEX_SITE_URL: z.string().optional(),
   },
   runtimeEnv: process.env,

--- a/convex/lib/constants.ts
+++ b/convex/lib/constants.ts
@@ -1,10 +1,3 @@
-// Environment variable names used by backend actions
-export const ENV_VARS = {
-  MAPBOX_API_KEY: 'MAPBOX_API_KEY',
-  ROBOFLOW_API_KEY: 'ROBOFLOW_API_KEY',
-  ROBOFLOW_BATCH: 'ROBOFLOW_BATCH',
-} as const;
-
 export const PERMISSIONS = {
   SCANS: {
     PREFIX: 'scans',

--- a/convex/lib/geocoding.ts
+++ b/convex/lib/geocoding.ts
@@ -1,6 +1,5 @@
-import { ENV_VARS } from './constants';
+import { env } from '../env';
 
-// Geocoding function to convert coordinates to readable location
 export async function reverseGeocode(
   lat: number,
   lng: number
@@ -8,7 +7,7 @@ export async function reverseGeocode(
   const apiStartTs = Date.now();
 
   try {
-    const MAPBOX_API_KEY = process.env[ENV_VARS.MAPBOX_API_KEY];
+    const MAPBOX_API_KEY = env.MAPBOX_API_KEY;
     if (!MAPBOX_API_KEY) {
       console.error('error: missing api key', {
         lat,

--- a/convex/lib/roboflow.ts
+++ b/convex/lib/roboflow.ts
@@ -1,5 +1,6 @@
 import type { CreateMLAnnotation } from './createml';
-import { ENV_VARS, ROBOFLOW_MODEL_NAME } from './constants';
+import { ROBOFLOW_MODEL_NAME } from './constants';
+import { env } from '../env';
 
 export interface RoboflowPrediction {
   x: number;
@@ -91,10 +92,10 @@ export async function detectObjectsWithRoboflow(
 export async function uploadImageToRoboflow({
   imageUrl,
   imageName,
-  apiKey = process.env[ENV_VARS.ROBOFLOW_API_KEY] || '',
+  apiKey = env.ROBOFLOW_API_KEY || '',
   datasetName = ROBOFLOW_MODEL_NAME || '',
   split = 'train',
-  batch = process.env[ENV_VARS.ROBOFLOW_BATCH] || 'User Contributed',
+  batch = env.ROBOFLOW_BATCH || 'User Contributed',
 }: {
   imageUrl: string;
   imageName: string;
@@ -187,7 +188,7 @@ export interface AnnotationUploadResponse {
 export async function uploadAnnotationToRoboflow({
   imageId,
   annotation,
-  apiKey = process.env[ENV_VARS.ROBOFLOW_API_KEY] || '',
+  apiKey = env.ROBOFLOW_API_KEY || '',
   datasetName = ROBOFLOW_MODEL_NAME || '',
   format = 'createml-json',
   name,

--- a/convex/lib/roboflow.ts
+++ b/convex/lib/roboflow.ts
@@ -92,10 +92,10 @@ export async function detectObjectsWithRoboflow(
 export async function uploadImageToRoboflow({
   imageUrl,
   imageName,
-  apiKey = env.ROBOFLOW_API_KEY || '',
+  apiKey = env.ROBOFLOW_API_KEY,
   datasetName = ROBOFLOW_MODEL_NAME || '',
   split = 'train',
-  batch = env.ROBOFLOW_BATCH || 'User Contributed',
+  batch = env.ROBOFLOW_BATCH,
 }: {
   imageUrl: string;
   imageName: string;
@@ -188,7 +188,7 @@ export interface AnnotationUploadResponse {
 export async function uploadAnnotationToRoboflow({
   imageId,
   annotation,
-  apiKey = env.ROBOFLOW_API_KEY || '',
+  apiKey = env.ROBOFLOW_API_KEY,
   datasetName = ROBOFLOW_MODEL_NAME || '',
   format = 'createml-json',
   name,

--- a/convex/lib/tiles.ts
+++ b/convex/lib/tiles.ts
@@ -1,5 +1,6 @@
 import type { RoboflowPrediction } from './roboflow';
-import { ENV_VARS, MAPBOX_TILE_DEFAULTS } from './constants';
+import { MAPBOX_TILE_DEFAULTS } from './constants';
+import { env } from '../env';
 
 export type TileCoordinate = {
   z: number;
@@ -78,7 +79,7 @@ export function styleTileUrl(
   }>
 ): string {
   const { username, styleId, tileSize, accessToken } = {
-    accessToken: process.env[ENV_VARS.MAPBOX_API_KEY],
+    accessToken: env.MAPBOX_API_KEY,
     ...MAPBOX_TILE_DEFAULTS,
     ...opts,
   };

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "@radix-ui/react-progress": "^1.1.7",
     "@radix-ui/react-switch": "^1.2.6",
     "@radix-ui/react-tabs": "^1.1.13",
+    "@t3-oss/env-core": "^0.13.11",
     "@tailwindcss/vite": "^4.1.13",
     "@tanstack/react-form": "^1.20.0",
     "@tanstack/react-query": "^5.89.0",

--- a/src/env.ts
+++ b/src/env.ts
@@ -1,0 +1,12 @@
+import { createEnv } from "@t3-oss/env-core";
+import { z } from "zod";
+
+export const env = createEnv({
+  clientPrefix: "VITE_",
+  client: {
+    VITE_CONVEX_URL: z.string().url(),
+    VITE_MAPBOX_API_KEY: z.string().min(1),
+  },
+  runtimeEnv: import.meta.env,
+  emptyStringAsUndefined: true,
+});

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -1,3 +1,5 @@
+import { env } from "@/env";
+
 // Map rendering thresholds
 export const PINS_VISIBLE_FROM_ZOOM = 10;
 
@@ -110,7 +112,7 @@ export function getVisualForClass(predictionClass: string): CourtClassVisual {
 }
 
 // Mapbox API configuration
-export const MAPBOX_API_KEY = import.meta.env.VITE_MAPBOX_API_KEY;
+export const MAPBOX_API_KEY = env.VITE_MAPBOX_API_KEY;
 
 // localStorage keys
 export const LOCALSTORAGE_KEYS = {

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -5,8 +5,9 @@ import { routeTree } from './routeTree.gen';
 import { ConvexAuthProvider } from '@convex-dev/auth/react';
 import { ConvexReactClient } from 'convex/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { env } from "@/env";
 
-const convex = new ConvexReactClient(import.meta.env.VITE_CONVEX_URL as string);
+const convex = new ConvexReactClient(env.VITE_CONVEX_URL);
 const router = createRouter({
   routeTree,
   defaultPreload: 'intent',


### PR DESCRIPTION
## Summary

- Adds `@t3-oss/env-core` for runtime-validated, type-safe environment variable access using Zod schemas
- Creates `src/env.ts` (Vite frontend) validating `VITE_CONVEX_URL` and `VITE_MAPBOX_API_KEY`
- Creates `convex/env.ts` (Convex backend) validating `MAPBOX_API_KEY`, `ROBOFLOW_API_KEY`, `ROBOFLOW_BATCH`, and `CONVEX_SITE_URL`
- Replaces all raw `import.meta.env` / `process.env` / `ENV_VARS` indirection with validated `env.*` imports
- Removes the `ENV_VARS` constant from `convex/lib/constants.ts`

## Test plan

- [ ] `bun check-types` passes (zero new errors)
- [ ] `bun dev` starts successfully with valid env vars
- [ ] Missing env vars produce clear Zod validation errors at startup